### PR TITLE
Create more robust url-loader matcher

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = {
   overrideWebpackConfig: ({ webpackConfig, cracoConfig, pluginOptions }) => {
     const config = { ...webpackConfig };
 
-    const urlLoader = getLoader(config, loaderByName('url-loader'));
+    const urlLoader = getLoader(config, imageUrlLoaderMatcher());
     const loader = urlLoader.match.loader;
 
     loader.use = [
@@ -26,4 +26,14 @@ module.exports = {
 
     return config;
   },
+};
+
+function imageUrlLoaderMatcher() {
+  const urlLoaderMatcher = loaderByName("url-loader");
+  const matcher = rule => urlLoaderMatcher(rule) &&
+    rule.test &&
+    (Array.isArray(rule.test)
+      ? rule.test.some(r => r.toString().indexOf("jpe?g") >= 0)
+      : rule.test.toString().indexOf("jpe?g") >= 0);
+  return matcher;
 };


### PR DESCRIPTION
The plugin does not work with react-scripts version 4.0.3 because of the inclusion in react-scripts webpack config of a second url-loader for the purposes of dealing with avif files:

```module: {
      strictExportPresence: true,
      rules: [
        // Disable require.ensure as it's not a standard language feature.
        { parser: { requireEnsure: false } },
        {
          // "oneOf" will traverse all following loaders until one will
          // match the requirements. When no loader matches it will fall
          // back to the "file" loader at the end of the loader list.
          oneOf: [
            // TODO: Merge this config once `image/avif` is in the mime-db
            // https://github.com/jshttp/mime-db
            {
              test: [/\.avif$/],
              loader: require.resolve('url-loader'),
              options: {
                limit: imageInlineSizeLimit,
                mimetype: 'image/avif',
                name: 'static/media/[name].[hash:8].[ext]',
              },
            },
            // "url" loader works like "file" loader except that it embeds assets
            // smaller than specified limit in bytes as data URLs to avoid requests.
            // A missing `test` is equivalent to a match.
            {
              test: [/\.gif$/, /\.jpe?g$/, /\.png$/],
              use: [
                {
                  loader: require.resolve('url-loader'),
                  options: {
                    limit: imageInlineSizeLimit,
                    name: 'static/media/[name].[hash:8].[ext]',
                  },
                },
                {
                  loader: require.resolve('image-webpack-loader')
                }
              ]

            },

```

Therefore the existing code to find the *actual* loader targeting images actually ends up targetting the `image/avif` loader instead.

By creating a new matcher:

```const { loaderByName } = require('@craco/craco');

function imageUrlLoaderMatcher() {
    const urlLoaderMatcher = loaderByName("url-loader");
    const matcher = rule => urlLoaderMatcher(rule) && rule.test && (Array.isArray(rule.test)
        ? rule.test.some(r => r.toString().indexOf("jpe?g") >= 0)
        : rule.test.toString().indexOf("jpe?g") >= 0);
    return matcher;
}```

we can ensure that the `image/avif` loader is skipped-over and the correct `url-loader` is targetted by this plugin.